### PR TITLE
Remove Queries module update

### DIFF
--- a/app/src/main/java/com/trianguloy/urlchecker/modules/list/RemoveQueriesModule.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/list/RemoveQueriesModule.java
@@ -49,7 +49,7 @@ class RemoveQueriesDialog extends AModuleDialog implements View.OnClickListener 
     private Button remove;
     private TextView more;
     private LinearLayout box;
-    private List<Button> queryButtons = new ArrayList<>();
+    private List<Button> queryKeyButtons = new ArrayList<>();
     private String[] queriesArray;
 
     private String cleared = null;
@@ -91,10 +91,10 @@ class RemoveQueriesDialog extends AModuleDialog implements View.OnClickListener 
         cleared = url.replaceAll("\\?[^#]*", "");
 
         // remove previously generated buttons
-        for (Button q : queryButtons) {
+        for (Button q : queryKeyButtons) {
             box.removeView(q);
         }
-        queryButtons = new ArrayList<>();
+        queryKeyButtons = new ArrayList<>();
 
         if (!cleared.equals(url)) {
             // query present, notify
@@ -107,19 +107,25 @@ class RemoveQueriesDialog extends AModuleDialog implements View.OnClickListener 
             queriesArray = extractQueries(url);
 
             // create a button for each query
-            // FIXME if multiple query keys are equal, multiple buttons will be created
-            for (String q : queriesArray) {
+            // if multiple query keys are equal, multiple buttons will be created, however these
+            // buttons will individually address each one in the order they are found
+            for (int i = 0; i < queriesArray.length; i++) {
                 Button queryRemover = new Button(box.getContext());
+                int queryN = i;
                 queryRemover.setOnClickListener(v -> {
-                    removeQuery((String) queryRemover.getText());
+                    removeQuery(queryN);
                 });
-                queryButtons.add(queryRemover);
-                // FIXME if text is too long button will be too, very unlikely
-                // FIXME style
-                queryRemover.setText(q.split("=")[0]);
+                queryKeyButtons.add(queryRemover);
+                // text will be the query key
+                String text = queriesArray[i].split("=")[0];
+
+                int maximumLength = 30;
+                if (maximumLength < text.length()){
+                    text = text.substring(0,maximumLength) + "...";
+                }
+                queryRemover.setText(text);
                 box.addView(queryRemover);
             }
-
         } else {
             // no query present, nothing to notify
             remove.setEnabled(false);
@@ -140,7 +146,7 @@ class RemoveQueriesDialog extends AModuleDialog implements View.OnClickListener 
         if (cleared != null) setUrl(cleared);
     }
 
-    public void removeQuery(String query) {
+    private void removeQuery(int n) {
         if (cleared != null){
             String oldUrl = getUrl();
             // copy everything from previous url, except queries and fragment
@@ -148,17 +154,17 @@ class RemoveQueriesDialog extends AModuleDialog implements View.OnClickListener 
 
             // to later check if we need to use '?' or '&'
             boolean firstQuery = true;
-            // FIXME will ignore ALL query keys that are equal to 'query'
-            for (String s : queriesArray) {
+
+            for (int i = 0; i < queriesArray.length; i++) {
                 // skip query to remove
-                if (!s.split("=")[0].equals(query)) {
+                if (i != n) {
                     if (firstQuery) {
                         newUrl.append('?');
                         firstQuery = false;
                     } else {
                         newUrl.append('&');
                     }
-                    newUrl.append(s);
+                    newUrl.append(queriesArray[i]);
                 }
             }
 

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/list/RemoveQueriesModule.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/list/RemoveQueriesModule.java
@@ -2,6 +2,7 @@ package com.trianguloy.urlchecker.modules.list;
 
 import android.view.View;
 import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.trianguloy.urlchecker.R;
@@ -11,6 +12,9 @@ import com.trianguloy.urlchecker.modules.AModuleConfig;
 import com.trianguloy.urlchecker.modules.AModuleData;
 import com.trianguloy.urlchecker.modules.AModuleDialog;
 import com.trianguloy.urlchecker.modules.DescriptionConfig;
+
+import java.util.List;
+import java.util.ArrayList;
 
 /**
  * This module removes queries "?foo=bar" from an url
@@ -43,6 +47,10 @@ class RemoveQueriesDialog extends AModuleDialog implements View.OnClickListener 
 
     private TextView info;
     private Button remove;
+    private TextView more;
+    private LinearLayout box;
+    private List<Button> queryButtons = new ArrayList<>();
+    private String[] queriesArray;
 
     private String cleared = null;
 
@@ -59,6 +67,17 @@ class RemoveQueriesDialog extends AModuleDialog implements View.OnClickListener 
     public void onInitialize(View views) {
         info = views.findViewById(R.id.text);
         remove = views.findViewById(R.id.fix);
+        more = views.findViewById(R.id.more);
+        box = views.findViewById(R.id.box);
+
+        // expand queries
+        more.setOnClickListener(v -> {
+            boolean checked = box.getVisibility() == View.GONE;
+            box.setVisibility(checked ? View.VISIBLE : View.GONE);
+            more.setCompoundDrawablesWithIntrinsicBounds(checked ? R.drawable.expanded : R.drawable.collapsed, 0, 0, 0);
+        });
+        more.performClick(); // initial hide
+
         remove.setOnClickListener(this);
     }
 
@@ -71,14 +90,45 @@ class RemoveQueriesDialog extends AModuleDialog implements View.OnClickListener 
         // this allows us to work with any string, even with non-standard urls
         cleared = url.replaceAll("\\?[^#]*", "");
 
+        // remove previously generated buttons
+        for (Button q : queryButtons) {
+            box.removeView(q);
+        }
+        queryButtons = new ArrayList<>();
+
         if (!cleared.equals(url)) {
             // query present, notify
             remove.setEnabled(true);
+            more.setEnabled(true);
             info.setText(R.string.mRemove_found);
             info.setBackgroundColor(getActivity().getResources().getColor(R.color.warning));
+
+            // extract queries
+            queriesArray = extractQueries(url);
+
+            // create a button for each query
+            // FIXME if multiple query keys are equal, multiple buttons will be created
+            for (String q : queriesArray) {
+                Button queryRemover = new Button(box.getContext());
+                queryRemover.setOnClickListener(v -> {
+                    removeQuery((String) queryRemover.getText());
+                });
+                queryButtons.add(queryRemover);
+                // FIXME if text is too long button will be too, very unlikely
+                // FIXME style
+                queryRemover.setText(q.split("=")[0]);
+                box.addView(queryRemover);
+            }
+
         } else {
             // no query present, nothing to notify
             remove.setEnabled(false);
+
+            // not pretty, but this sets 'more' on collapsed
+            box.setVisibility(View.VISIBLE);
+            more.performClick();
+
+            more.setEnabled(false);
             info.setText(R.string.mRemove_noQueries);
             info.setBackgroundColor(getActivity().getResources().getColor(R.color.transparent));
         }
@@ -90,4 +140,41 @@ class RemoveQueriesDialog extends AModuleDialog implements View.OnClickListener 
         if (cleared != null) setUrl(cleared);
     }
 
+    public void removeQuery(String query) {
+        if (cleared != null){
+            String oldUrl = getUrl();
+            // copy everything from previous url, except queries and fragment
+            StringBuilder newUrl = new StringBuilder(oldUrl.substring(0, oldUrl.indexOf("?")));
+
+            // to later check if we need to use '?' or '&'
+            boolean firstQuery = true;
+            // FIXME will ignore ALL query keys that are equal to 'query'
+            for (String s : queriesArray) {
+                // skip query to remove
+                if (!s.split("=")[0].equals(query)) {
+                    if (firstQuery) {
+                        newUrl.append('?');
+                        firstQuery = false;
+                    } else {
+                        newUrl.append('&');
+                    }
+                    newUrl.append(s);
+                }
+            }
+
+            // add fragment
+            if (oldUrl.contains("#")){
+                newUrl.append(oldUrl.substring(oldUrl.indexOf("#")));
+            }
+            setUrl(newUrl.toString());
+        }
+    }
+
+    private String[] extractQueries(String url){
+        int start = url.indexOf("?") + 1;
+        int end = url.indexOf("#");
+        end = end == -1 ? url.length() : end;
+        String queriesString = url.substring(start, end);
+        return queriesString.split("&");
+    }
 }

--- a/app/src/main/res/layout/dialog_removequeries.xml
+++ b/app/src/main/res/layout/dialog_removequeries.xml
@@ -2,20 +2,43 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="center_vertical">
+    android:gravity="center_vertical"
+    android:orientation="vertical">
 
-    <Button
-        android:id="@+id/fix"
-        style="?android:attr/buttonBarButtonStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_weight="0"
-        android:text="@string/mRemove_apply" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal">
 
-    <TextView
-        android:id="@+id/text"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1" />
+        <Button
+            android:id="@+id/fix"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="0"
+            android:text="@string/mRemove_apply" />
 
+        <TextView
+            android:id="@+id/more"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:drawableStart="@drawable/collapsed"
+            android:drawableLeft="@drawable/collapsed"
+            android:gravity="center_vertical"
+            android:padding="5dp"
+            android:textSize="15sp" />
+
+        <TextView
+            android:id="@+id/text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/box"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"></LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,7 +112,7 @@ This module can\'t be disabled."</string>
     <string name="mClear_error">An error occurred while checking rules</string>
 
     <string name="mRemove_name">Remove Queries</string>
-    <string name="mRemove_desc">This module removes all queries from the url.\nThanks to PabloOQ for the idea and original implementation!</string>
+    <string name="mRemove_desc">With this module you can remove queries from the URL.\nPress the button to remove all queries or press the arrow to remove queries one at a time.\nThanks to PabloOQ for the idea and original implementation!</string>
     <string name="mRemove_found">Queries found</string>
     <string name="mRemove_noQueries">No queries</string>
     <string name="mRemove_apply">Apply</string>


### PR DESCRIPTION
Update to the Remove Queries module, as requested in #9. Now you can remove queries one at a time, if needed. There is an arrow next to the 'Apply' button, this arrow will expand a section with a button for each query key, tapping any button will result in removing that specific query parameter.

Things to keep in mind, if there are multiple queries with the same key, each one can be removed individually, their buttons will appear in the same order they are found.

Code for the expandable box is from `ConfigActivity.java`.

