### PR TITLE
ClearURLs module update

### DIFF
--- a/app/src/main/java/com/trianguloy/urlchecker/modules/list/ClearUrlModule.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/list/ClearUrlModule.java
@@ -159,6 +159,7 @@ class ClearUrlConfig extends AModuleConfig {
                 String jsonString = readFromUrl(databaseSource);
                 JSONObject sourceJson = new JSONObject(jsonString);
                 if (checkHash) {
+                    // TODO ? if the hash is the same as the downloaded file, there is no need to download the database
                     MessageDigest md = MessageDigest.getInstance("SHA-256");
                     md.update(jsonString.getBytes(Charset.forName("UTF-8")));
                     String encoded = encodeHex(md.digest());
@@ -189,6 +190,7 @@ class ClearUrlConfig extends AModuleConfig {
                 e.printStackTrace();
             }
         }
+        // FIXME inform user if it succeeded or not and why
         downloading = false;
     }
 
@@ -265,7 +267,7 @@ class ClearUrlDialog extends AModuleDialog implements View.OnClickListener {
     private final GenericPref.Bool allowReferral = ClearUrlModule.REFERRAL_PREF();
     private final GenericPref.Bool verbose = ClearUrlModule.VERBOSE_PREF();
     private final GenericPref.Bool auto = ClearUrlModule.AUTO_PREF();
-    private final GenericPref.Bool customPref = ClearUrlModule.CUSTOM_PREF();
+    private final GenericPref.Bool custom = ClearUrlModule.CUSTOM_PREF();
 
     private JSONObject data = null;
     private TextView info;
@@ -278,10 +280,10 @@ class ClearUrlDialog extends AModuleDialog implements View.OnClickListener {
         allowReferral.init(dialog);
         verbose.init(dialog);
         auto.init(dialog);
-        customPref.init(dialog);
+        custom.init(dialog);
         
         boolean error = false;
-        if (customPref.get()) {
+        if (custom.get()) {
             // use custom database
             try {
                 // TODO fall back if file is downloading?
@@ -292,7 +294,7 @@ class ClearUrlDialog extends AModuleDialog implements View.OnClickListener {
                 error = true;
             }
         }
-        if (!customPref.get() || error) {
+        if (!custom.get() || error) {
             // use built-in database
             try {
                 data = new JSONObject(getJsonFromAssets(dialog, getActivity().getString(R.string.mClear_database))).getJSONObject("providers");

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/list/ClearUrlModule.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/list/ClearUrlModule.java
@@ -24,6 +24,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.BufferedReader;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -32,6 +33,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -132,7 +134,8 @@ class ClearUrlConfig extends AModuleConfig {
             if (!downloading) {
                 downloading = true;
                 new Thread(() -> {
-                    replaceDatabase("", databaseURL.get(), "", false);
+                    replaceDatabase(views.getContext().getString(R.string.mClear_database),
+                            databaseURL.get(), "", false, views.getContext());
                 }).start();
             }
         });
@@ -141,13 +144,16 @@ class ClearUrlConfig extends AModuleConfig {
     /**
      * Replaces the database with a new one
      */
-    private void replaceDatabase(String file, String source, String hash, boolean checkHash){
-        try {
+    private void replaceDatabase(String filename, String source, String hash, boolean checkHash, Context context){
+
+        try (FileOutputStream fos = context.openFileOutput(filename, Context.MODE_PRIVATE)){
             JSONObject sourceJson = readJsonFromUrl(source);
+
+            fos.write(sourceJson.toString().getBytes(Charset.forName("UTF-8")));
         } catch (JSONException | IOException e) {
             e.printStackTrace();
         }
-        // TODO store in app-specific files
+
         downloading = false;
     }
 

--- a/app/src/main/res/layout/config_clearurls.xml
+++ b/app/src/main/res/layout/config_clearurls.xml
@@ -33,12 +33,12 @@
         android:text="@string/mClear_sourceDesc" />
 
     <EditText
-        android:id="@+id/clear_source"
+        android:id="@+id/database_URL"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:autofillHints=""
         android:ems="10"
-        android:hint="@string/mClear_source"
+        android:hint="database_URL"
         android:inputType="none|text" />
 
     <TextView
@@ -53,23 +53,22 @@
         android:orientation="horizontal">
 
         <CheckBox
-            android:id="@+id/checkBox"
+            android:id="@+id/checkHash"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:checked="true" />
+            android:layout_height="wrap_content" />
 
         <EditText
-            android:id="@+id/clear_hash"
+            android:id="@+id/hash_URL"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:autofillHints=""
             android:ems="10"
-            android:hint="@string/mClear_hash"
+            android:hint="hash_URL"
             android:inputType="none|text" />
     </LinearLayout>
 
     <Button
-        android:id="@+id/clear_update"
+        android:id="@+id/update"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/mClear_update" />

--- a/app/src/main/res/layout/config_clearurls.xml
+++ b/app/src/main/res/layout/config_clearurls.xml
@@ -27,6 +27,18 @@
         android:text="@string/mClear_toggleVerbose" />
 
     <TextView
+        android:id="@+id/textView4"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/mClear_customDBdesc" />
+
+    <CheckBox
+        android:id="@+id/customDB"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/mClear_customDB" />
+
+    <TextView
         android:id="@+id/textView2"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -71,7 +83,7 @@
         android:id="@+id/update"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/mClear_update" />
+        android:text="@string/mClear_download" />
 
     <TextView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/config_clearurls.xml
+++ b/app/src/main/res/layout/config_clearurls.xml
@@ -27,6 +27,54 @@
         android:text="@string/mClear_toggleVerbose" />
 
     <TextView
+        android:id="@+id/textView2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/mClear_sourceDesc" />
+
+    <EditText
+        android:id="@+id/clear_source"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:autofillHints=""
+        android:ems="10"
+        android:hint="@string/mClear_source"
+        android:inputType="none|text" />
+
+    <TextView
+        android:id="@+id/textView3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/mClear_hashDesc" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal">
+
+        <CheckBox
+            android:id="@+id/checkBox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="true" />
+
+        <EditText
+            android:id="@+id/clear_hash"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:autofillHints=""
+            android:ems="10"
+            android:hint="@string/mClear_hash"
+            android:inputType="none|text" />
+    </LinearLayout>
+
+    <Button
+        android:id="@+id/clear_update"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/mClear_update" />
+
+    <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:autoLink="web"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@ This module can\'t be disabled."</string>
     <string name="mClear_sourceDesc">URL of the custom database JSON file with the rules:</string>
     <string name="mClear_hashDesc">URL of the hash of the custom database, must be in lowercase. Can be ignored if the checkbox is disabled:</string>
     <string name="mClear_download">Download</string>
+    <string name="mClear_downloadSuccess">Custom DB successfully downloaded</string>
     <string name="mClear_database">data.minify.json</string>
     <string name="mClear_tm">Uses the Clear URL database from https://docs.clearurls.xyz/latest/specs/rules/</string>
     <string name="mClear_clear">Apply</string>
@@ -119,6 +120,7 @@ This module can\'t be disabled."</string>
     <string name="mClear_toggleReferral">Enable referral marketing (referral parameters won\'t be cleared)</string>
     <string name="mClear_toggleVerbose">Enable verbose info for the matching process</string>
     <string name="mClear_error">An error occurred while checking rules</string>
+    <string name="mClear_customDBLoadError">Custom DB load failed, falling back to built-in DB</string>
 
     <string name="mRemove_name">Remove Queries</string>
     <string name="mRemove_desc">With this module you can remove queries from the URL.\nPress the button to remove all queries or press the arrow to remove queries one at a time.\nThanks to PabloOQ for the idea and original implementation!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,10 +98,9 @@ This module can\'t be disabled."</string>
     <string name="mClear_name">Clear URL</string>
     <string name="mClear_desc">This module removes tracking, referrer and other useless parameters from the url. It also allows for common offline url redirections.</string>
     <string name="mClear_sourceDesc">URL of the database JSON file with the rules:</string>
-    <string name="mClear_source">https://rules2.clearurls.xyz/data.minify.json</string>
-    <string name="mClear_hashDesc">URL of the hash of the source:</string>
-    <string name="mClear_hash">https://rules2.clearurls.xyz/rules.minify.hash</string>
+    <string name="mClear_hashDesc">URL of the hash of the source, can be ignored if the checkbox is deactivated:</string>
     <string name="mClear_update">Update</string>
+    <string name="mClear_database">data.minify.json</string>
     <string name="mClear_tm">Uses the Clear URL database from https://docs.clearurls.xyz/latest/specs/rules/</string>
     <string name="mClear_clear">Apply</string>
     <string name="mClear_matches">Matches %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,7 +100,7 @@ This module can\'t be disabled."</string>
     <string name="mClear_customDBdesc">By default the app uses a built-in database, but you can download a new one and use that instead. The default values of the urls are the source of the built-in database, so it can be used to download a newer version as a custom database, a hash (SHA256) can be used to ensure a correct download.</string>
     <string name="mClear_customDB">Use custom database</string>
     <string name="mClear_sourceDesc">URL of the custom database JSON file with the rules:</string>
-    <string name="mClear_hashDesc">URL of the hash of the custom database, can be ignored if the checkbox is disabled:</string>
+    <string name="mClear_hashDesc">URL of the hash of the custom database, must be in lowercase. Can be ignored if the checkbox is disabled:</string>
     <string name="mClear_download">Download</string>
     <string name="mClear_database">data.minify.json</string>
     <string name="mClear_tm">Uses the Clear URL database from https://docs.clearurls.xyz/latest/specs/rules/</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,9 +97,11 @@ This module can\'t be disabled."</string>
 
     <string name="mClear_name">Clear URL</string>
     <string name="mClear_desc">This module removes tracking, referrer and other useless parameters from the url. It also allows for common offline url redirections.</string>
-    <string name="mClear_sourceDesc">URL of the database JSON file with the rules:</string>
-    <string name="mClear_hashDesc">URL of the hash of the source, can be ignored if the checkbox is deactivated:</string>
-    <string name="mClear_update">Update</string>
+    <string name="mClear_customDBdesc">By default the app uses a built-in database, but you can download a new one and use that instead. The default values of the urls are the source of the built-in database, so it can be used to download a newer version as a custom database, a hash (SHA256) can be used to ensure a correct download.</string>
+    <string name="mClear_customDB">Use custom database</string>
+    <string name="mClear_sourceDesc">URL of the custom database JSON file with the rules:</string>
+    <string name="mClear_hashDesc">URL of the hash of the custom database, can be ignored if the checkbox is disabled:</string>
+    <string name="mClear_download">Download</string>
     <string name="mClear_database">data.minify.json</string>
     <string name="mClear_tm">Uses the Clear URL database from https://docs.clearurls.xyz/latest/specs/rules/</string>
     <string name="mClear_clear">Apply</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,11 @@ This module can\'t be disabled."</string>
 
     <string name="mClear_name">Clear URL</string>
     <string name="mClear_desc">This module removes tracking, referrer and other useless parameters from the url. It also allows for common offline url redirections.</string>
+    <string name="mClear_sourceDesc">URL of the database JSON file with the rules:</string>
+    <string name="mClear_source">https://rules2.clearurls.xyz/data.minify.json</string>
+    <string name="mClear_hashDesc">URL of the hash of the source:</string>
+    <string name="mClear_hash">https://rules2.clearurls.xyz/rules.minify.hash</string>
+    <string name="mClear_update">Update</string>
     <string name="mClear_tm">Uses the Clear URL database from https://docs.clearurls.xyz/latest/specs/rules/</string>
     <string name="mClear_clear">Apply</string>
     <string name="mClear_matches">Matches %s</string>


### PR DESCRIPTION
As requested on #3.
This update lets the user download a custom database from the internet, by default the database URL in preferences is the one from ClearURLs, so it can be used to "update" the database.
For debugging and testing purposes [I have my own database](https://github.com/PabloOQ/Rules) with only google as provider and a new rule "testing".
There are a few things to be done, or to decide if they should be done, these are properly indicated in the code with FIXME and TODO tags.  As well as fixing and changing everything you see fit. 