### PR TITLE
Open and share update

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,17 @@
                 <data android:scheme="https" />
             </intent-filter>
             <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+
+                <data android:mimeType="text/html" />
+            </intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />

--- a/app/src/main/java/com/trianguloy/urlchecker/utilities/GenericPref.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/utilities/GenericPref.java
@@ -4,12 +4,17 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
 import android.widget.EditText;
+import android.widget.Spinner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.ListIterator;
 
 /**
  * A generic type preference
@@ -101,6 +106,81 @@ public abstract class GenericPref<T> {
         }
     }
 
+
+    /**
+     * An Integer preference
+     */
+    static public class Int extends GenericPref<Integer> {
+        public Int(String prefName, Integer defaultValue) {
+            super(prefName, defaultValue);
+        }
+
+        @Override
+        public Integer get() {
+            return prefs.getInt(prefName, defaultValue);
+        }
+
+        @Override
+        public void set(Integer value) {
+            prefs.edit().putInt(prefName, value).apply();
+        }
+
+        /**
+         * Stores a key and the string representation
+         */
+        public static class AdapterPair{
+            public final Integer key;
+            public final String name;
+
+            public AdapterPair(Integer key, String name) {
+                this.key = key;
+                this.name = name;
+            }
+
+            @Override
+            public String toString() {
+                return name;
+            }
+        }
+
+        /**
+         * Uses a List of AdapterPair to populate a spinner
+         */
+        public void attachToSpinner(Spinner spinner, List<AdapterPair> elements){
+            // Put elements in the spinner
+            ArrayAdapter<AdapterPair> adapter =
+                    new ArrayAdapter<>(spinner.getContext(),
+                            android.R.layout.simple_spinner_item,
+                            elements);
+            adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+            spinner.setAdapter(adapter);
+
+            // To select current preference, as Key doesn't necessarily match index
+            // There's probably a better way to do this
+            int selection = get();
+            ListIterator<AdapterPair> it = elements.listIterator();
+            while (it.hasNext()){
+                if (it.next().key == selection){
+                    spinner.setSelection(it.previousIndex());
+                    // Key values should not be repeated
+                    break;
+                }
+            }
+
+            spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+                @Override
+                public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+                    AdapterPair el = (AdapterPair) adapterView.getItemAtPosition(i);
+                    set(el.key);
+                }
+
+                @Override
+                public void onNothingSelected(AdapterView<?> adapterView) {
+
+                }
+            });
+        }
+    }
     /**
      * A boolean preference
      */

--- a/app/src/main/res/drawable/mopen_auto.xml
+++ b/app/src/main/res/drawable/mopen_auto.xml
@@ -1,0 +1,10 @@
+<vector android:autoMirrored="true"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <path
+        android:fillColor="@color/app"
+        android:pathData="M9.4,16.6L4.8,12l4.6,-4.6L8,6l-6,6 6,6 1.4,-1.4zM14.6,16.6l4.6,-4.6 -4.6,-4.6L16,6l6,6 -6,6 -1.4,-1.4z" />
+</vector>

--- a/app/src/main/res/drawable/mopen_exclude_recents.xml
+++ b/app/src/main/res/drawable/mopen_exclude_recents.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/app"
+        android:pathData="M3,4h8v15h-8z" />
+    <path
+        android:fillColor="@color/app"
+        android:pathData="M13,4h8v15h-8z" />
+
+</vector>

--- a/app/src/main/res/drawable/mopen_inside.xml
+++ b/app/src/main/res/drawable/mopen_inside.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/app"
+        android:pathData="M7,4h10v15h-10z" />
+</vector>

--- a/app/src/main/res/layout/config_open.xml
+++ b/app/src/main/res/layout/config_open.xml
@@ -21,4 +21,15 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
+    <TextView
+        android:id="@+id/textView3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/mOpen_presetFlagsSetting" />
+
+    <Spinner
+        android:id="@+id/presetflags_pref"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/config_open.xml
+++ b/app/src/main/res/layout/config_open.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/mOpen_desc" />
+
+    <TextView
+        android:id="@+id/textView2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/mOpen_ctabsSetting" />
+
+    <Spinner
+        android:id="@+id/ctabs_pref"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_open.xml
+++ b/app/src/main/res/layout/dialog_open.xml
@@ -1,51 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="center_vertical">
-
-    <ImageButton
-        android:id="@+id/ctabs"
-        style="?android:attr/buttonBarButtonStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:src="@drawable/ctabs_off" />
+    android:gravity="center_vertical"
+    android:orientation="vertical">
 
     <LinearLayout
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/open_both"
         android:orientation="horizontal">
 
-        <Button
-            android:id="@+id/open"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:background="@drawable/open_left"
-            android:minHeight="60dp"
-            android:padding="5dp"
-            android:text="@string/mOpen_open"
-            android:textColor="?android:attr/colorBackground"
-            android:textStyle="bold" />
-
         <ImageButton
-            android:id="@+id/open_with"
+            android:id="@+id/expand"
             style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:background="@drawable/open_right"
-            android:paddingRight="1dp"
-            android:src="@drawable/arrow_down"
+            android:src="@drawable/arrow_right"
             android:tint="?attr/colorAccent" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@drawable/open_both"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/open"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:background="@drawable/open_left"
+                android:minHeight="60dp"
+                android:paddingLeft="5dp"
+                android:paddingRight="5dp"
+                android:text="@string/mOpen_open"
+                android:textColor="?android:attr/colorBackground"
+                android:textStyle="bold" />
+
+            <ImageButton
+                android:id="@+id/open_with"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:background="@drawable/open_right"
+                android:paddingRight="1dp"
+                android:src="@drawable/arrow_down"
+                android:tint="?attr/colorAccent" />
+
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/share"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:text="@string/mOpen_share" />
 
     </LinearLayout>
 
-    <Button
-        android:id="@+id/share"
-        style="?android:attr/buttonBarButtonStyle"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/advanced"
+        android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="@string/mOpen_share" />
+        android:layout_weight="1"
+        android:orientation="horizontal">
+
+        <ImageButton
+            android:id="@+id/ctabs"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:src="@drawable/ctabs_off" />
+
+        <ImageButton
+            android:id="@+id/presetflags"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:src="@drawable/mopen_auto" />
+    </LinearLayout>
+
 </LinearLayout>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -58,17 +58,26 @@ Nota: si editas los patrones, nuevos patrones incorporados en futuras actualizac
 
     <string name="mOpen_name"><![CDATA[Abrir y compartir]]></string>
     <string name="mOpen_desc">"Contiene los siguientes botones (de izquierda a derecha):
-- Botón de 'custom tabs': activa/desactiva la característica de 'custom tabs'. Cuando se activa el navegador se debería abrir en un modo reducido 'lite'.
 - Boton de abrir: pulsa el nombre de la aplicación para abrir el enlace en ella. Si un enlace puede ser abierto por varias se mostrará una flecha para poder elegir.
 - Botón de compartir: Púlsalo para compartir el enlace. Mantenlo pulsado para copiarlo diréctamente en el navegador.
+Botones de las opciones avanzadas (de izquierda a derecha):
+- Botón de 'custom tabs': activa/desactiva la característica de 'custom tabs'. Cuando se activa el navegador se debería abrir en un modo reducido 'lite'.
+- Botón de plantilla al abrir: rota entre los diferentes modos para abrir la url:
+        - Temporal: Después de abrir la url, cuando salga de la app esta se cerrará automáticamente.
+        - Nueva ventana: Abre la app de forma independiente.
 Este módulo no puede ser deshabilitado."</string>
     <string name="mOpen_ctabsSetting">"Estado por defecto de 'Custom tabs':"</string>
+    <string name="mOpen_presetFlagsSetting">Plantilla por defecto:</string>
+    <string name="mOpen_optionExcludeRecents">Nueva ventana</string>
+    <string name="mOpen_optionInside">Temporal</string>
     <string name="mOpen_with">Abrir con %s</string>
     <string name="mOpen_open">Abrir</string>
     <string name="mOpen_share">Compartir</string>
     <string name="mOpen_clipboard">Url copiada al portapapeles</string>
     <string name="mOpen_noapps">Sin aplicaciones</string>
     <string name="mOpen_tabsDesc">"Activa/desactiva 'custom tabs'"</string>
+    <string name="mOpen_rotatePresetFlags">Rota las plantillas</string>
+
 
     <string name="mStatus_name">Código de estado</string>
     <string name="mStatus_desc">"Al pulsar el botón de comprobar, se realizará una peticion para obtener y mostrar el código de estado de la url.

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -28,6 +28,9 @@ Traducciones: %s."</string>
     <string name="reset">Reiniciar</string>
     <string name="close">Cerrar</string>
     <string name="clear">Borrar</string>
+    <string name="auto">Automático</string>
+    <string name="enabled">Activado</string>
+    <string name="disabled">Desactivado</string>
 
     <string name="json_desc">[Funcionalidad beta] Este es un editor avanzado, el contenido debe ser JSON válido. Puedes pulsar el botón de arriba a la derecha para formatearlo y validarlo.</string>
     <string name="json_edit">Editor avanzado</string>
@@ -59,6 +62,7 @@ Nota: si editas los patrones, nuevos patrones incorporados en futuras actualizac
 - Boton de abrir: pulsa el nombre de la aplicación para abrir el enlace en ella. Si un enlace puede ser abierto por varias se mostrará una flecha para poder elegir.
 - Botón de compartir: Púlsalo para compartir el enlace. Mantenlo pulsado para copiarlo diréctamente en el navegador.
 Este módulo no puede ser deshabilitado."</string>
+    <string name="mOpen_ctabsSetting">"Estado por defecto de 'Custom tabs':"</string>
     <string name="mOpen_with">Abrir con %s</string>
     <string name="mOpen_open">Abrir</string>
     <string name="mOpen_share">Compartir</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,10 @@ Translations: %s."</string>
     <string name="reset">Reset</string>
     <string name="close">Close</string>
     <string name="clear">Clear</string>
+    <string name="auto">Auto</string>
+    <string name="enabled">Enabled</string>
+    <string name="disabled">Disabled</string>
+
 
     <string name="json_desc">[Beta feature] This is an advanced editor, the content must be formatted into valid JSON. You can press the top-right button to format and validate it.</string>
     <string name="json_edit">Advanced editor</string>
@@ -59,6 +63,7 @@ Note: if you edit the patterns, new built-in patterns from app updates will not 
 - Open button: Press the app name to open the link on that app. If a link can be opened with multiple apps, an arrow will be shown to let you choose.
 - Share button: Press the button to share the link. Long press to quickly copy to clipboard.
 This module can't be disabled."</string>
+    <string name="mOpen_ctabsSetting">Custom tabs default state:</string>
     <string name="mOpen_with">Open with %s</string>
     <string name="mOpen_open">Open</string>
     <string name="mOpen_share">Share</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,17 +59,25 @@ Note: if you edit the patterns, new built-in patterns from app updates will not 
 
     <string name="mOpen_name"><![CDATA[Open & Share]]></string>
     <string name="mOpen_desc">"Contains the following buttons (left to right):
-- Custom Tabs button: toggle to enable/disable the custom tab feature. When enabled the browser should be opened in a 'lite' mode.
 - Open button: Press the app name to open the link on that app. If a link can be opened with multiple apps, an arrow will be shown to let you choose.
 - Share button: Press the button to share the link. Long press to quickly copy to clipboard.
+Advanced options buttons (left to right):
+- Custom Tabs button: toggle to enable/disable the custom tab feature. When enabled the browser should be opened in a 'lite' mode.
+- Open preset button: rotates between different modes to open the url:
+        - Temporal: After opening the url, when you exit the app it will close.
+        - New window: Opens the app independently.
 This module can't be disabled."</string>
     <string name="mOpen_ctabsSetting">Custom tabs default state:</string>
+    <string name="mOpen_presetFlagsSetting">Open presets default state:</string>
+    <string name="mOpen_optionExcludeRecents">New window</string>
+    <string name="mOpen_optionInside">Temporal</string>
     <string name="mOpen_with">Open with %s</string>
     <string name="mOpen_open">Open</string>
     <string name="mOpen_share">Share</string>
     <string name="mOpen_clipboard">Url copied to clipboard</string>
     <string name="mOpen_noapps">No apps</string>
     <string name="mOpen_tabsDesc">Toggle Custom Tabs feature</string>
+    <string name="mOpen_rotatePresetFlags">Rotate open presets</string>
 
     <string name="mStatus_name">Status code</string>
     <string name="mStatus_desc">"By pressing the check button, a petition will be made to retrieve and display the site status code.


### PR DESCRIPTION
Fix #14 
First commit of the branch, easy fix of the manifest.

[Added Integer preference](https://github.com/TrianguloY/UrlChecker/commit/a49d6d04927196737a79f9d080d9088fc5490ecd)
I didn't reuse long because the item selected on the spinners give an int not long. This should be of use to attach any spinner to a preference, could be useful to choose the language as a preference, or select night mode.

Implemented #39 

Suggested solution for #37
Preset flags feature: There are a number of presets flags to apply to the intent, overriding all previous flags. To make space for the button a dropdown was added, which contains any additional settings of the module that can be modified in the dialog. There are 2 presets at the moment:
- Temporal: Works as the [twitter video 'inside' ](https://github.com/TrianguloY/UrlChecker/issues/37#issuecomment-1205743582). Doesn't always work, depends on the app, it didn't work on Brave for me, but it did on Firefox focus, YT and Twitter for example. 
- New window: Works as the [youtube video 'outside' ](https://github.com/TrianguloY/UrlChecker/issues/37#issuecomment-1205743582)
There are 3 icons added, the `mopen_auto.xml` icon was just copy paste from other icon as I didn't know what it should be. When the feature detects that the intent is the same as one of the presets it will not show the auto icon while rotating the presets in the dialog.

I intentionally added the preset flags feature the last so it can be easily reverted or entirely ditched, as I must admit the solution is somewhat weird. Feel free to remove it if you feel it doesn't fit the app.

Each commit has it's spanish translation too if there was any string added.