### PR TITLE
Assets update action

### DIFF
--- a/.github/scripts/file-updater.sh
+++ b/.github/scripts/file-updater.sh
@@ -1,0 +1,48 @@
+# Retrieve parameters
+fileName=$1
+fileURL=$2
+path=$3
+hashURL=$4
+
+# Temporal folder to work on
+# Needed in case a file is updated in the main folder, and the hash checking fails
+downloadFolder="./.file_updater_action_temporal_folder/"
+mkdir $downloadFolder
+tempPath="$downloadFolder$fileName"
+
+# Store checksum
+curlHashExit=1
+if [ "$path" != "" ]; then
+  checksum=$(curl $hashURL)
+  curlHashExit=$?
+fi
+
+# Avoid download of same file
+oldFileChecksum=$(sha256sum "$path$fileName")
+if [ "$oldFileChecksum" = "$checksum  $path$fileName" ]; then
+  echo "Current file checksum is the same as the new one"
+  exit 1
+fi
+
+# Download file
+curl "$fileURL" -o $tempPath
+curlFileExit=$?
+
+# If both downloads were succesful
+if [[ $curlFileExit -eq 0 && $curlHashExit -eq 0 ]]; then
+  # Checksum of file
+  dlFileChecksum=$(sha256sum $tempPath)
+  # If matches
+  if [ "$dlFileChecksum" = "$checksum  $tempPath" ]; then
+    mv $tempPath "$path$fileName"
+    # No need to check exit code, if mv fails GitHub actions will too
+  else
+    # If not, failure
+    echo "Hash does not match" >&2
+    exit 2
+  fi
+else
+  # If not, failure
+  echo "Downloads failed" >&2
+  exit 3
+fi

--- a/.github/workflows/assets-updater.yml
+++ b/.github/workflows/assets-updater.yml
@@ -1,0 +1,41 @@
+# This action updates assets files
+name: Assets updater
+
+on:
+  
+permissions:
+  contents: write
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository content
+        # https://github.com/actions/checkout
+        uses: actions/checkout@v3
+
+      - name: ClearURLs catalog
+        continue-on-error: true
+        run: |
+          bash ./.github/scripts/file-updater.sh $fileName $fileURL $filePath $hashURL
+          git add "$filePath$fileName"
+          echo "$fileName added successfully"
+        env:
+          fileName: "data.minify.json"
+          fileURL: "https://rules2.clearurls.xyz/data.minify.json"
+          filePath: "./app/src/main/assets/"
+          hashURL: "https://rules2.clearurls.xyz/rules.minify.hash"
+
+      - name: Commit everything and push
+        run: |
+          # Retrieve finished steps as number value
+          count=($(git diff --staged --name-only | wc))
+          if [[ ${count[0]} -ne 0 ]]; then
+            git config user.name GithubActions
+            git config user.email ""
+            git commit -m "Update assets"
+            git push
+          else
+            echo "None of the files were updated"
+          fi

--- a/.github/workflows/assets-updater.yml
+++ b/.github/workflows/assets-updater.yml
@@ -2,40 +2,59 @@
 name: Assets updater
 
 on:
-  
+ # weekly
+ schedule:
+   - cron: '0 0 * * Sun'
+    
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   download:
     runs-on: ubuntu-latest
 
+    env:
+      workingBranch: assets-updater-action
     steps:
-      - name: Checkout repository content
-        # https://github.com/actions/checkout
+      - name: Checkout main
         uses: actions/checkout@v3
+
+      - name: Git config
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Check if branch exists
+        run: |
+          count=($(git ls-remote --heads origin "$workingBranch" | wc))
+          if [[ ${count[0]} -ne 0 ]]; then
+            # Exists
+            git fetch
+            git checkout -b $workingBranch "origin/$workingBranch"
+          else
+            # Does not exist
+            git checkout -b $workingBranch
+            git push --set-upstream origin $workingBranch
+          fi
 
       - name: ClearURLs catalog
         continue-on-error: true
         run: |
           bash ./.github/scripts/file-updater.sh $fileName $fileURL $filePath $hashURL
           git add "$filePath$fileName"
-          echo "$fileName added successfully"
+          git commit -m "$message"
+          git push
+          echo "$fileName commited successfully"
         env:
           fileName: "data.minify.json"
-          fileURL: "https://rules2.clearurls.xyz/data.minify.json"
+          fileURL: "https://rules2.clearurls.xyz/data.min.json"
           filePath: "./app/src/main/assets/"
-          hashURL: "https://rules2.clearurls.xyz/rules.minify.hash"
+          hashURL: "https://rules2.clearurls.xyz/rules.min.hash"
+          message: "ClearURLs catalog updated"
 
-      - name: Commit everything and push
-        run: |
-          # Retrieve finished steps as number value
-          count=($(git diff --staged --name-only | wc))
-          if [[ ${count[0]} -ne 0 ]]; then
-            git config user.name GithubActions
-            git config user.email ""
-            git commit -m "Update assets"
-            git push
-          else
-            echo "None of the files were updated"
-          fi
+      - name: Pull request
+        run:
+          gh pr create --title 'Automated assets updater action' --body ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This action updates assets files, currently there is only one asset file, the ClearURLs catalog, but  the action can be easily expanded if more are added ( maybe these issues can benefit from it: #82 #61 #10 #7 ), just copy and paste the ClearURLS catalog step and change the enviroment variables.

I think that even with the built-in catalog updater the app should come bundled with a recent file.

The script **needs** a hash url to confirm a successful download, I thought of removing this resctrition, but I don't like the idea of auto-commiting without some kind of verification. If a source doesn't have a hash to confirm it can be solved by forking the repo and adding an action to automatically sync with main every now and then, after that the action could just generate the hash.

The action won't fail if an asset could not be updated as it is aimed to update more than one file at the same time, these failures include:

- Hash does not match
- Folder does not exist
- The new file hash is the same as the current one
- Download failed

If the PR is merged it's important to keep in mind that the field `on:` is intentionally left out, I leave to you to decide when to run it the action, these are some that I thought could be useful:

- Manually

```
# manually
workflow_dispatch:
```

  - On release, this one would update the file after the release tag, so the file won't be technically updated until the next release
```
 # on releases
 release:
```

- I think actions can be called from other actions, so this can be added in an action that makes the releases (apk and all that) too .

- Weekly

```
 # weekly
 schedule:
   - cron: '0 0 * * Sun'
```

Finally, here are some [tests](https://github.com/PabloOQ/UrlChecker/actions). Because the action does not fail if the asset update fails you would need to enter to the workflow run and check the console log of the steps to see the result.