### PR TITLE
Basic PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,7 +12,8 @@ Github:
 
 # Add 'Core' label to any change within the 'core' package
 Core:
-- app/src/main/java/com/trianguloy/urlchecker/**/*
+- app/src/main/java/**/*
+- app/src/main/kotlin/**/*
 
 # Add 'Store file' label to any change within the 'play' folder and subfolder(s)
 Store file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,14 +22,10 @@ Store file:
 Gradle wrapper:
 - gradle/wrapper/**/*
 
-# Add 'Ongoing translation' label to any change to strings.xml files
+# Add 'Ongoing translation` label to any change to strings.xml files as long as the English strings.xml file hasn't changed
 Ongoing translation:
-- app/src/main/res/values-es/strings.xml
-- app/src/main/res/values-fr-rFR/strings.xml
-- app/src/main/res/values-iw/strings.xml
-- app/src/main/res/values-pt-rPT/strings.xml
-- app/src/main/res/values-tr/strings.xml
-- app/src/main/res/values-uk/strings.xml
+- any: ['app/src/**/strings.xml']
+  all: ['!app/src/main/res/values/strings.xml']
 
 # Add language code label to any change to specific strings.xml files
 es-ES:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,52 @@
+# Made with love
+# see https://github.com/actions/labeler
+# for more informations
+
+# Add 'assets' label to any assets file changes within the source dir
+Assets:
+- app/src/main/assets/**/*
+
+# Add 'Github' label to any git file changes within the source dir
+Github:
+- .github/**/*
+
+# Add 'Core' label to any change within the 'core' package
+Core:
+- app/src/main/java/com/trianguloy/urlchecker/**/*
+
+# Add 'Store file' label to any change within the 'play' folder and subfolder(s)
+Store file:
+- app/src/main/play/**/*
+
+# Add 'Gradle wrapper' label to any change within the 'gradle' folder and subfolder
+Gradle wrapper:
+- gradle/wrapper/**/*
+
+# Add 'Ongoing translation' label to any change to strings.xml files
+Ongoing translation:
+- app/src/main/res/values-es/strings.xml
+- app/src/main/res/values-fr-rFR/strings.xml
+- app/src/main/res/values-iw/strings.xml
+- app/src/main/res/values-pt-rPT/strings.xml
+- app/src/main/res/values-tr/strings.xml
+- app/src/main/res/values-uk/strings.xml
+
+# Add language code label to any change to specific strings.xml files
+es-ES:
+- app/src/main/res/values-es/strings.xml
+
+fr-rFR:
+- app/src/main/res/values-fr-rFR/strings.xml
+
+iw-IL:
+- app/src/main/res/values-iw/strings.xml
+
+pt-rPT:
+- app/src/main/res/values-pt-rPT/strings.xml
+
+tr-TR:
+- app/src/main/res/values-tr/strings.xml
+
+uk-UA:
+- app/src/main/res/values-uk/strings.xml
+

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,27 +22,8 @@ Store file:
 Gradle wrapper:
 - gradle/wrapper/**/*
 
-# Add 'Ongoing translation` label to any change to strings.xml files as long as the English strings.xml file hasn't changed
-Ongoing translation:
+# Add 'Translation` label to any change to strings.xml files as long as the English strings.xml file hasn't changed
+Translation:
 - any: ['app/src/**/strings.xml']
   all: ['!app/src/main/res/values/strings.xml']
-
-# Add language code label to any change to specific strings.xml files
-es-ES:
-- app/src/main/res/values-es/strings.xml
-
-fr-rFR:
-- app/src/main/res/values-fr-rFR/strings.xml
-
-iw-IL:
-- app/src/main/res/values-iw/strings.xml
-
-pt-rPT:
-- app/src/main/res/values-pt-rPT/strings.xml
-
-tr-TR:
-- app/src/main/res/values-tr/strings.xml
-
-uk-UA:
-- app/src/main/res/values-uk/strings.xml
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true


### PR DESCRIPTION
Small proposal, after a lot of testing (of nonsense too) and back and forth, here is a "basic" labeler (it will surely require additions and modifications).

It labels the PRs of:

- modifications of language files (strings.xml): adds the double label "Ongoing translation" and the language code (for example "es-ES" for Spanish) according to the modified file.

- internal files ("Core" label)
when editing files in the `app/src/main/java/com/trianguloy/urlchecker` folder and all its subfolders

- Adds the "Github" label when modifying files in the `.github` folder and subfolders

- Adds the label "Assets" when modifying files in the `app/src/main/assets` folder and its subfolders

- Adds the label "Store file" when modifying files in the `app/src/main/play` folder and its subfolders

- Adds the label "Gradle wrapper" when modifying files in the `gradle` folder and its subfolders

It works (normally) perfectly well.
(Sorry for the delay)