### PR TITLE
Copy to clipboard from debug module

### DIFF
--- a/app/src/main/java/com/trianguloy/urlchecker/modules/list/DebugModule.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/list/DebugModule.java
@@ -1,13 +1,8 @@
 package com.trianguloy.urlchecker.modules.list;
 
-import android.content.ClipData;
-import android.content.ClipboardManager;
-import android.content.Context;
-import android.os.Build;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.trianguloy.urlchecker.R;
 import com.trianguloy.urlchecker.activities.ConfigActivity;
@@ -17,6 +12,7 @@ import com.trianguloy.urlchecker.modules.AModuleData;
 import com.trianguloy.urlchecker.modules.AModuleDialog;
 import com.trianguloy.urlchecker.services.CustomTabs;
 import com.trianguloy.urlchecker.url.UrlData;
+import com.trianguloy.urlchecker.utilities.AndroidUtils;
 import com.trianguloy.urlchecker.utilities.GenericPref;
 
 /**
@@ -89,10 +85,10 @@ class DebugDialog extends AModuleDialog implements View.OnClickListener ,View.On
     public void onClick(View v) {
         switch (v.getId()) {
             case R.id.intent:
-                copyToClipboard(R.string.mD_copyIntent, txt_intent.getText().toString());
+                AndroidUtils.copyToClipboard(getActivity(), R.string.mD_copyIntent, txt_intent.getText().toString());
                 break;
             case R.id.urlData:
-                copyToClipboard(R.string.mD_copyUrlData, txt_urlData.getText().toString());
+                AndroidUtils.copyToClipboard(getActivity(), R.string.mD_copyUrlData, txt_urlData.getText().toString());
                 break;
         }
     }
@@ -102,26 +98,12 @@ class DebugDialog extends AModuleDialog implements View.OnClickListener ,View.On
         switch (v.getId()) {
             case R.id.intent:
             case R.id.urlData:
-                copyToClipboard(R.string.mD_copyAll, txt_intent.getText() + "\n" + txt_urlData.getText());
+                AndroidUtils.copyToClipboard(getActivity(), R.string.mD_copyAll, txt_intent.getText() + "\n" + txt_urlData.getText());
                 break;
             default:
                 return false;
         }
         return true;
-    }
-
-    /**
-     * Copy to the clipboard, retrieves string from id
-     */
-    private void copyToClipboard(int id, String text) {
-        ClipboardManager clipboard = (ClipboardManager) getActivity().getSystemService(Context.CLIPBOARD_SERVICE);
-        if (clipboard == null) return;
-
-        clipboard.setPrimaryClip(ClipData.newPlainText("",  text));
-
-        // show toast to notify it was copied (except on Android 13+, where the device shows a popup itself)
-        if (Build.VERSION.SDK_INT < /*Build.VERSION_CODES.TIRAMISU*/33)
-            Toast.makeText(getActivity(), id, Toast.LENGTH_LONG).show();
     }
 }
 

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/list/DebugModule.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/list/DebugModule.java
@@ -1,8 +1,13 @@
 package com.trianguloy.urlchecker.modules.list;
 
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.os.Build;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.trianguloy.urlchecker.R;
 import com.trianguloy.urlchecker.activities.ConfigActivity;
@@ -49,8 +54,9 @@ public class DebugModule extends AModuleData {
     }
 }
 
-class DebugDialog extends AModuleDialog {
+class DebugDialog extends AModuleDialog implements View.OnClickListener ,View.OnLongClickListener{
 
+    private TextView txt_intent;
     private TextView txt_urlData;
 
     public DebugDialog(MainDialog dialog) {
@@ -69,10 +75,53 @@ class DebugDialog extends AModuleDialog {
 
     @Override
     public void onInitialize(View views) {
-        ((TextView) views.findViewById(R.id.intent)).setText(
-                getActivity().getIntent().toUri(0)
-        );
+        txt_intent = views.findViewById(R.id.intent);
+        txt_intent.setText(getActivity().getIntent().toUri(0));
+        txt_intent.setOnClickListener(this);
+        txt_intent.setOnLongClickListener(this);
+
         txt_urlData = views.findViewById(R.id.urlData);
+        txt_urlData.setOnClickListener(this);
+        txt_urlData.setOnLongClickListener(this);
+    }
+
+    @Override
+    public void onClick(View v) {
+        switch (v.getId()) {
+            case R.id.intent:
+                copyToClipboard(R.string.mD_copyIntent, txt_intent.getText().toString());
+                break;
+            case R.id.urlData:
+                copyToClipboard(R.string.mD_copyUrlData, txt_urlData.getText().toString());
+                break;
+        }
+    }
+
+    @Override
+    public boolean onLongClick(View v) {
+        switch (v.getId()) {
+            case R.id.intent:
+            case R.id.urlData:
+                copyToClipboard(R.string.mD_copyAll, txt_intent.getText() + "\n" + txt_urlData.getText());
+                break;
+            default:
+                return false;
+        }
+        return true;
+    }
+
+    /**
+     * Copy to the clipboard, retrieves string from id
+     */
+    private void copyToClipboard(int id, String text) {
+        ClipboardManager clipboard = (ClipboardManager) getActivity().getSystemService(Context.CLIPBOARD_SERVICE);
+        if (clipboard == null) return;
+
+        clipboard.setPrimaryClip(ClipData.newPlainText("",  text));
+
+        // show toast to notify it was copied (except on Android 13+, where the device shows a popup itself)
+        if (Build.VERSION.SDK_INT < /*Build.VERSION_CODES.TIRAMISU*/33)
+            Toast.makeText(getActivity(), id, Toast.LENGTH_LONG).show();
     }
 }
 

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/list/OpenModule.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/list/OpenModule.java
@@ -1,11 +1,7 @@
 package com.trianguloy.urlchecker.modules.list;
 
-import android.content.ClipData;
-import android.content.ClipboardManager;
-import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -24,6 +20,7 @@ import com.trianguloy.urlchecker.modules.AModuleDialog;
 import com.trianguloy.urlchecker.modules.companions.CTabs;
 import com.trianguloy.urlchecker.modules.companions.LastOpened;
 import com.trianguloy.urlchecker.url.UrlData;
+import com.trianguloy.urlchecker.utilities.AndroidUtils;
 import com.trianguloy.urlchecker.utilities.GenericPref;
 import com.trianguloy.urlchecker.utilities.PackageUtilities;
 import com.trianguloy.urlchecker.utilities.UrlUtilities;
@@ -190,7 +187,7 @@ class OpenDialog extends AModuleDialog implements View.OnClickListener, PopupMen
                 Toast.makeText(getActivity(), R.string.mOpen_tabsDesc, Toast.LENGTH_SHORT).show();
                 break;
             case R.id.share:
-                copyToClipboard();
+                AndroidUtils.copyToClipboard(getActivity(), R.string.mOpen_clipboard, getUrl());
                 break;
             default:
                 return false;
@@ -315,20 +312,6 @@ class OpenDialog extends AModuleDialog implements View.OnClickListener, PopupMen
         if (closeSharePref.get()){
             this.getActivity().finish();
         }
-    }
-
-    /**
-     * Copy the url to the clipboard
-     */
-    private void copyToClipboard() {
-        ClipboardManager clipboard = (ClipboardManager) getActivity().getSystemService(Context.CLIPBOARD_SERVICE);
-        if (clipboard == null) return;
-
-        clipboard.setPrimaryClip(ClipData.newPlainText("", getUrl()));
-
-        // show toast to notify it was copied (except on Android 13+, where the device shows a popup itself)
-        if (Build.VERSION.SDK_INT < /*Build.VERSION_CODES.TIRAMISU*/33)
-            Toast.makeText(getActivity(), R.string.mOpen_clipboard, Toast.LENGTH_LONG).show();
     }
 
     /**

--- a/app/src/main/java/com/trianguloy/urlchecker/utilities/AndroidUtils.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/utilities/AndroidUtils.java
@@ -1,6 +1,8 @@
 package com.trianguloy.urlchecker.utilities;
 
 import android.app.Activity;
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.PorterDuff;
@@ -11,6 +13,7 @@ import android.text.style.ClickableSpan;
 import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.trianguloy.urlchecker.BuildConfig;
 import com.trianguloy.urlchecker.R;
@@ -108,5 +111,26 @@ public class AndroidUtils {
                         ? cntx.getResources().getConfiguration().getLocales().get(0)
                         : cntx.getResources().getConfiguration().locale
         ).format(new Date(millis));
+    }
+
+    /**
+     * Copy to the clipboard, retrieves string from id
+     */
+    public static void copyToClipboard(Activity activity, int id, String text) {
+        copyToClipboard(activity, activity.getString(id), text);
+    }
+
+    /**
+     * Copy to the clipboard
+     */
+    public static void copyToClipboard(Activity activity, String toast, String text) {
+        ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
+        if (clipboard == null) return;
+
+        clipboard.setPrimaryClip(ClipData.newPlainText("",  text));
+
+        // show toast to notify it was copied (except on Android 13+, where the device shows a popup itself)
+        if (Build.VERSION.SDK_INT < /*Build.VERSION_CODES.TIRAMISU*/33)
+            Toast.makeText(activity, toast, Toast.LENGTH_LONG).show();
     }
 }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -120,8 +120,13 @@ Se necesita una clave de la API de VirusTotal para que funcione, puedes obtener 
     <string name="mD_name">Módulo debug/marcador</string>
     <string name="mD_desc">"Si reordenas los módulos, los que se añadan en futuras actualizaciones serán colocados encima de este.
 
-Si lo habilitas, mostrará el intent recibido como uri, útil para desarrolladores."</string>
+Si lo habilitas, mostrará el intent recibido como uri, útil para desarrolladores.
+
+Pulsa en el Intent o en UrlData para copiarlo al portapapeles. Mantenlo pulsado para copiarlo todo."</string>
     <string name="mD_ctabs">Mostrar mensajes de debug del servicio custom tabs</string>
+    <string name="mD_copyIntent">Intent copiado al portapapeles</string>
+    <string name="mD_copyUrlData">UrlData copiado al portapapeles</string>
+    <string name="mD_copyAll">Intent y UrlData copiados al portapapeles</string>
 
     <string name="mHist_name">Historial</string>
     <string name="mHist_desc">Cuando la url cambia, tanto manualmente como por otros módulos, éste te permite ver y revertir los cambios.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,8 +121,13 @@ A personal VirusTotal API key is needed for it to work, you can get one after re
     <string name="mD_name">Debug/Marker module</string>
     <string name="mD_desc">"If you reorder the modules, new ones added in future updates will be placed above this one.
 
-If you enable this it will display the received intent as uri, useful for developers."</string>
+If you enable this it will display the received intent as uri, useful for developers.
+
+Tap on Intent or UrlData to copy to the clipboard. Hold to copy everything."</string>
     <string name="mD_ctabs">Show debug messages from the custom tabs service</string>
+    <string name="mD_copyIntent">Intent copied to clipboard</string>
+    <string name="mD_copyUrlData">UrlData copied to clipboard</string>
+    <string name="mD_copyAll">Intent and UrlData copied to clipboard</string>
 
     <string name="mHist_name">History</string>
     <string name="mHist_desc">When the url is edited, either manually or by other modules, this one allows you to view and revert changes.</string>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:7.2.2'
         
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
 I made it because I found an app that wouldn't open links from URLCheck but it would from [Open link with](https://github.com/tasomaniac/OpenLinkWith/) after being shared from URLCheck (did not open either when sharing from URLCheck to URLCheck). When I wanted to compare the Intents ( `App->URLCheck-share->Open link with->URLCheck` ,  `App->URLCheck` ), I had to take 2 screenshots and I thought it would be more convenient to be able to copy it to the clipboard. I will open an issue or fix it after doing more research.

When tapped it will copy the `text` from the `TextView` that has been tapped, when held it will copy both.
Because this module is for developing I think the strings should match the code, that's why I didn't translate `Intent` and `UrlData`,

The second commit is to avoid code duplication.