### PR TITLE
Change the url of the play store badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Translations: [Tiago Carmo](https://github.com/ReduxFlakes), [Ilithy](https://gi
 
 [![GitHub version (gradle versionName)](https://img.shields.io/badge/dynamic/json?label=Latest%20version&color=white&query=version&url=https%3A%2F%2Fgithub.com%2FTrianguloY%2FUrlChecker%2Freleases%2Fdownload%2Flatest%2Fshields.json)](https://github.com/TrianguloY/UrlChecker/blob/master/app/build.gradle)
 [![F-Droid](https://img.shields.io/f-droid/v/com.trianguloy.urlchecker?label=F-Droid%20version)](https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/com.trianguloy.urlchecker.yml)
-[![PlayShields](https://img.shields.io/endpoint?color=green&url=https%3A%2F%2Fplayshields.herokuapp.com%2Fplay%3Fi%3Dcom.trianguloy.urlchecker%26l%3DPlay%2520Store%2520version%26m%3Dv%24version)](https://play.google.com/store/apps/details?id=com.trianguloy.urlchecker)
+[![PlayShields](https://img.shields.io/endpoint?color=green&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcom.trianguloy.urlchecker%26l%3DPlay%2520Store%2520version%26m%3Dv%24version)](https://play.google.com/store/apps/details?id=com.trianguloy.urlchecker)
 
 </div>
 


### PR DESCRIPTION
Changes the domain of the play store badge

The old service is running on a free heroku account, but [Heroku will stop offering free accounts](https://help.heroku.com/RSBRUH58/removal-of-heroku-free-product-plans-faq) at the end of November.
The [new service](https://github.com/cvzi/play) is running on a free Cloudflare worker.