### PR TITLE
[Action] Release apk on GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Build & Publish Release APK
+
+on:
+  push:
+    tags:
+      - '*'
+
+  workflow_dispatch:
+
+jobs:
+  Gradle:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout code
+      uses: actions/checkout@v3
+    - name: setup jdk
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Make Gradle executable
+      run: chmod +x ./gradlew
+    - name: Build Release APK
+      run: ./gradlew assembleRelease
+    - name: Release to GitHub
+      uses: Ilithy/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ./app/build/outputs/apk/release/app-release-unsigned.apk
+        asset_name: URLCheck.apk
+        tag: ${{ github.ref }}
+        overwrite: true
+        body: "URLCheck app release"

--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@
 
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
 alt="Get it on F-Droid"
-height="80">](https://f-droid.org/packages/com.trianguloy.urlchecker)
+height="65">](https://f-droid.org/packages/com.trianguloy.urlchecker)
 [<img src="https://github.com/Ilithy/Ilithy/blob/f22b1faadd6d673d1c37cb36d6f338ca2c01a564/Art/get-it-on-github.png"
 alt="Get it on Github"
-height="80">](https://github.com/TrianguloY/UrlChecker/releases)
+height="65">](https://github.com/TrianguloY/UrlChecker/releases)
 [<img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png"
 alt="Get it on Google Play"
-height="80">](https://play.google.com/store/apps/details?id=com.trianguloy.urlchecker)
+height="65">](https://play.google.com/store/apps/details?id=com.trianguloy.urlchecker)
 [<img src="https://github.com/Ilithy/Ilithy/blob/f22b1faadd6d673d1c37cb36d6f338ca2c01a564/Art/get-it-on-APK_Pure.png"
 alt="Get it on APKPure"
-height="80">](https://m.apkpure.com/urlcheck/com.trianguloy.urlchecker)
+height="65">](https://m.apkpure.com/urlcheck/com.trianguloy.urlchecker)
 
 
 </div>

--- a/README.md
+++ b/README.md
@@ -26,9 +26,17 @@
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
 alt="Get it on F-Droid"
 height="80">](https://f-droid.org/packages/com.trianguloy.urlchecker)
+[<img src="https://github.com/Ilithy/Ilithy/blob/f22b1faadd6d673d1c37cb36d6f338ca2c01a564/Art/get-it-on-github.png"
+alt="Get it on Github"
+height="80">](https://github.com/TrianguloY/UrlChecker/releases)
 [<img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png"
 alt="Get it on Google Play"
-height="80">](https://play.google.com/store/apps/details?id=com.trianguloy.urlchecker) 
+height="80">](https://play.google.com/store/apps/details?id=com.trianguloy.urlchecker)
+[<img src="https://github.com/Ilithy/Ilithy/blob/f22b1faadd6d673d1c37cb36d6f338ca2c01a564/Art/get-it-on-APK_Pure.png"
+alt="Get it on APKPure"
+height="80">](https://m.apkpure.com/urlcheck/com.trianguloy.urlchecker)
+
+
 </div>
 <!-- <details><summary><h4>links</h4></summary>
 

--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@
 
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
 alt="Get it on F-Droid"
-height="65">](https://f-droid.org/packages/com.trianguloy.urlchecker)
+height="50">](https://f-droid.org/packages/com.trianguloy.urlchecker)
 [<img src="https://github.com/Ilithy/Ilithy/blob/f22b1faadd6d673d1c37cb36d6f338ca2c01a564/Art/get-it-on-github.png"
 alt="Get it on Github"
-height="65">](https://github.com/TrianguloY/UrlChecker/releases)
+height="50">](https://github.com/TrianguloY/UrlChecker/releases)
 [<img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png"
 alt="Get it on Google Play"
-height="65">](https://play.google.com/store/apps/details?id=com.trianguloy.urlchecker)
+height="50">](https://play.google.com/store/apps/details?id=com.trianguloy.urlchecker)
 [<img src="https://github.com/Ilithy/Ilithy/blob/f22b1faadd6d673d1c37cb36d6f338ca2c01a564/Art/get-it-on-APK_Pure.png"
 alt="Get it on APKPure"
-height="65">](https://m.apkpure.com/urlcheck/com.trianguloy.urlchecker)
+height="50">](https://m.apkpure.com/urlcheck/com.trianguloy.urlchecker)
 
 
 </div>


### PR DESCRIPTION
Hi;
This PR introduces a github action to create an apk file and make it available on github.
- the action is automatic when creating a new version (when a new tag is created)
- the action can be launched manually

Other changes:

- Added 'get it on github' badge
- Added 'get it on APKPure' badge
- Modification of the size of the "_get it on_" badges (to have them on one line on a majority of screens)

Thank you.