### PR TITLE
Add deny browser to open/share functionality

### DIFF
--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/DenylistOption.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/DenylistOption.java
@@ -1,0 +1,50 @@
+package com.trianguloy.urlchecker.modules.companions;
+
+import com.trianguloy.urlchecker.R;
+import com.trianguloy.urlchecker.utilities.Enums;
+
+/**
+ * Enum representing the app that can be hidden from "Open with" and "Share via".
+
+ * Each entry has:
+ * An id (for saving as a preference),
+ * A label (string resource for UI),
+ * The actual package name of the app to filter out.
+
+ */
+
+public enum DenylistOption implements Enums.IdEnum, Enums.StringEnum {
+    NONE(0, R.string.denylist_none, null),
+    CHROME(1, R.string.denylist_chrome, "com.android.chrome"),
+    FIREFOX(2, R.string.denylist_firefox, "org.mozilla.firefox"),
+    EDGE(3, R.string.denylist_edge, "com.microsoft.emmx"),
+    OPERA(4, R.string.denylist_opera, "com.opera.browser"),
+    BRAVE(5, R.string.denylist_brave, "com.brave.browser");
+
+    private final int id;
+    private final int labelRes;
+    private final String packageName;
+
+    DenylistOption(int id, int labelRes, String packageName) {
+        this.id = id;
+        this.labelRes = labelRes;
+        this.packageName = packageName;
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    public int getStringResource() {
+        return labelRes;
+    }
+
+    /**
+     * This is the name that will be denied
+     * Could update to a list of dynamically made sites in the future
+     */
+    public String getPackageName() {
+        return packageName;
+    }
+}

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ShareUtility.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ShareUtility.java
@@ -1,15 +1,23 @@
 package com.trianguloy.urlchecker.modules.companions;
 
+
+import java.util.List;
+import java.util.ArrayList;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.view.View;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.widget.Toast;
 
 import com.trianguloy.urlchecker.R;
 import com.trianguloy.urlchecker.dialogs.MainDialog;
 import com.trianguloy.urlchecker.utilities.generics.GenericPref;
 import com.trianguloy.urlchecker.utilities.methods.AndroidUtils;
 import com.trianguloy.urlchecker.utilities.methods.PackageUtils;
+import com.trianguloy.urlchecker.modules.list.OpenModule;
 
 /**
  * The share functionality.
@@ -75,19 +83,52 @@ public interface ShareUtility {
 
         /** Shares the url as text */
         public void shareUrl() {
-            // create send intent
-            var sendIntent = new Intent();
-            sendIntent.setAction(Intent.ACTION_SEND);
-            sendIntent.putExtra(Intent.EXTRA_TEXT, mainDialog.getUrlData().url);
-            sendIntent.setType("text/plain");
 
-            // share intent
-            var chooser = Intent.createChooser(sendIntent, mainDialog.getString(R.string.mOpen_share));
-            PackageUtils.startActivity(
-                    chooser,
-                    R.string.mOpen_noapps,
-                    mainDialog
-            );
+            // creates send intent
+            Intent baseIntent = new Intent(Intent.ACTION_SEND);
+            baseIntent.putExtra(Intent.EXTRA_TEXT, mainDialog.getUrlData().url);
+            baseIntent.setType("text/plain");
+
+
+            DenylistOption deny = OpenModule.DENYLIST_PREF(mainDialog).get();
+            String packageToRemove = deny != null ? deny.getPackageName() : null;
+
+            // Gets the denied preference and applied it
+            PackageManager pm = mainDialog.getPackageManager();
+            List<ResolveInfo> resolveInfos = pm.queryIntentActivities(baseIntent, 0);
+
+            // Shows specific apps based on user preference
+            List<Intent> targetedIntents = new ArrayList<>();
+            for (ResolveInfo ri : resolveInfos) {
+                String packageName = ri.activityInfo.packageName;
+                if (packageToRemove != null && packageName.equals(packageToRemove)) {
+                    continue; // skip denied app (doesn't add it)
+                }
+
+                Intent targeted = new Intent(baseIntent);
+                targeted.setPackage(packageName);
+                targeted.setClassName(packageName, ri.activityInfo.name);
+                targetedIntents.add(targeted);
+            }
+
+            //If nothing is shown, it shows toast
+            if (targetedIntents.isEmpty()) {
+                Toast.makeText(mainDialog, R.string.mOpen_noapps, Toast.LENGTH_SHORT).show();
+                return;
+            }
+
+            //Build chooser so we can provide the denied list
+            Intent chooser = Intent.createChooser(targetedIntents.remove(0),
+                    mainDialog.getString(R.string.mOpen_share));
+
+            // add the rest of the filtered as EXTRA_INITIAL_INTENTS
+            if (!targetedIntents.isEmpty()) {
+                chooser.putExtra(Intent.EXTRA_INITIAL_INTENTS,
+                        targetedIntents.toArray(new Intent[0]));
+            }
+
+            PackageUtils.startActivity(chooser, R.string.mOpen_noapps, mainDialog);
+
             if (closeSharePref.get()) {
                 mainDialog.finish();
             }

--- a/app/src/main/res/layout/config_open.xml
+++ b/app/src/main/res/layout/config_open.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -101,7 +102,7 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/smallPadding"
         android:orientation="horizontal">
 
@@ -117,6 +118,24 @@
             android:layout_height="wrap_content"
             android:layout_weight="1" />
 
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/textView5"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:text="Deny Browser" />
+
+        <Spinner
+            android:id="@+id/denylist_pref"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -247,6 +247,14 @@ Note: if you edit the patterns, new built-in patterns from app updates will not 
     <string name="mOpen_rejected">Hide app if URL was rejected (an app immediately requests to open the same URL it was opened with). Doesn\'t affect sharing.</string>
     <string name="mOpen_mergeCopy">Merge Copy and Share buttons (long press to copy)</string>
     <string name="mOpen_iconSize">Icon size</string>
+
+    <string name="denylist_none">None Denied</string>
+    <string name="denylist_chrome">Deny Chrome</string>
+    <string name="denylist_firefox">Deny Firefox</string>
+    <string name="denylist_edge">Deny Edge</string>
+    <string name="denylist_opera">Deny Opera</string>
+    <string name="denylist_brave">Deny Brave</string>
+
     <string name="mOpen_with">Open with %s</string>
     <string name="mOpen_open">Open</string>
     <string name="mOpen_share">Share</string>


### PR DESCRIPTION
I saw that someone had requested for there to be less browsers based on user preference so I was able to add something that removed one browser from chrome, edge, opera, brave and Firefox that user did not like. In future, could update to include more apps and maybe even increase the amount of apps available to deny at a single time to be an actual list.