### PR TITLE
PatternChecker: Fix Twitter domain, and replace Teddit with Eddrit

### DIFF
--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/PatternCatalog.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/PatternCatalog.java
@@ -58,7 +58,7 @@ public class PatternCatalog extends JsonCatalog {
                         .put("enabled", false)
                 )
                 .put("Twitter ➔ Nitter", new JSONObject()
-                        .put("regex", "^https?://(?:[a-z0-9-]+\\.)*?(twitter|x)\\.com/(.*)")
+                        .put("regex", "^https?://(?:[a-z0-9-]+\\.)*?(?:twitter|x)\\.com/(.*)")
                         .put("replacement", "https://nitter.net/$1")
                         .put("enabled", false)
                 )


### PR DESCRIPTION
Twitter changed their domain to x.com, but you might still find the old domain in links.

Teddit is no longer working, replaced with Eddrit.