### PR TITLE
Restrict songlink pattern to music streaming URLs

### DIFF
--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/PatternCatalog.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/PatternCatalog.java
@@ -84,7 +84,7 @@ public class PatternCatalog extends JsonCatalog {
                         .put("enabled", false)
                 )
 
-                // excludeRegex example
+                // excludeRegex example. Consider replacing with another service that allows all urls
                 .put("URL ➔ Songlink", new JSONObject()
                         .put("regex", "^https?://(?:www\\.)?(open\\.spotify\\.com|music\\.apple\\.com|(?:music\\.)?youtube\\.com/watch|youtu\\.be|soundcloud\\.com|tidal\\.com|deezer\\.com|[^/]*\\.bandcamp\\.com|music\\.amazon\\.com)")
                         .put("excludeRegex", "^https://song\\.link/")

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/PatternCatalog.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/PatternCatalog.java
@@ -84,8 +84,9 @@ public class PatternCatalog extends JsonCatalog {
                         .put("enabled", false)
                 )
 
-                // excludeRegex example. Consider replacing with another service that really allows all urls
+                // excludeRegex example
                 .put("URL ➔ Songlink", new JSONObject()
+                        .put("regex", "^https?://(?:www\\.)?(open\\.spotify\\.com|music\\.apple\\.com|(?:music\\.)?youtube\\.com/watch|youtu\\.be|soundcloud\\.com|tidal\\.com|deezer\\.com|[^/]*\\.bandcamp\\.com|music\\.amazon\\.com)")
                         .put("excludeRegex", "^https://song\\.link/")
                         .put("replacement", "https://song.link/$0")
                         .put("enabled", false)


### PR DESCRIPTION
Fixes #566

The songlink module was replacing every URL. Added a regex pattern to only match music streaming services so the replacement doesn't interfere with other links.